### PR TITLE
bump gcc to 8.5 on amazon-linux-2

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -60,6 +60,11 @@ jobs:
             glibc: "2.26"
             linux: "4.14"
             gcc: "7.3.0"
+          - target: aarch64-aws2-linux-gnu
+            vendor: aws2
+            glibc: "2.26"
+            linux: "4.14"
+            gcc: "8.5.0"
           - target: aarch64-aws2023-linux-gnu
             vendor: aws2023
             glibc: "2.34"
@@ -71,6 +76,11 @@ jobs:
             glibc: "2.26"
             linux: "4.14"
             gcc: "7.3.0"
+          - target: x86_64-aws2-linux-gnu
+            vendor: aws2
+            glibc: "2.26"
+            linux: "4.14"
+            gcc: "8.5.0"
 
 
     steps:


### PR DESCRIPTION
[KAG-5335](https://konghq.atlassian.net/browse/KAG-5335)

[KAG-5335]: https://konghq.atlassian.net/browse/KAG-5335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ